### PR TITLE
feat: switch default branch to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,10 @@ name: build
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
+      - "main"
 
 jobs:
   docker:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
       - "*"
   push:
     branches:
-      - "master"
+      - "main"
 
 jobs:
   hadolint:

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -5,7 +5,7 @@ name: trivy-analysis
 on:
   push:
     branches:
-      - master
+      - "main"
   pull_request:
 
 jobs:
@@ -23,13 +23,13 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'docker.io/dokku/ambassador:${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          image-ref: "docker.io/dokku/ambassador:${{ github.sha }}"
+          format: "template"
+          template: "@/contrib/sarif.tpl"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
Due to local tooling updates, all the other Dokku repositories are converging on 'main' as the default. This makes my local workflows for interacting with this repository annoying as I need to remember if the repo uses main or master. As such, the default branch is moving to main to reduce cognitive overhead while I maintain the repository.